### PR TITLE
Require rspec/core explicitly

### DIFF
--- a/lib/pundit/matchers.rb
+++ b/lib/pundit/matchers.rb
@@ -1,3 +1,5 @@
+require 'rspec/core'
+
 module Pundit
   module Matchers
     RSpec::Matchers.define :permit_action do |action|


### PR DESCRIPTION
When pundit-matchers is loaded in the test environment, it appears that rspec hasn't been initialized, which throws an error when running 'RAILS_ENV=test bundle exec rake db:create db:schema:load'. This will ensure that rspec is required before defining pundit-matcher's matchers. 

This should address #1 