### PR TITLE
Simplify gem dependencies to support rspec 3.5 beta (and Rails 5)

### DIFF
--- a/pundit-matchers.gemspec
+++ b/pundit-matchers.gemspec
@@ -10,6 +10,5 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://github.com/chrisalley/pundit-matchers'
   s.license     = 'MIT'
   s.add_dependency 'pundit', '~> 1.0', '>= 1.0.0'
-  s.add_dependency 'rspec', '~> 3.0', '>= 3.0.0'
-  s.add_dependency 'rspec-rails', '~> 3.0', '>= 3.0.0'
+  s.add_dependency 'rspec-rails', '>= 3.0.0'
 end


### PR DESCRIPTION
I'm using Rails 5 and rspec 3.5.0, and the gem dependencies were complaining.

I have tried simplifying them to allow for rspec 3.5 and everything seems to work fine.