### PR TITLE
Add support for action arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ group:
 
 ```ruby
 group :test do
-  gem 'pundit-matchers', '~> 1.2.3'
+  gem 'pundit-matchers', '~> 1.3.0'
 end
 ```
 
@@ -42,6 +42,8 @@ files (by convention, saved in the `spec/policies` directory).
 
 * `permit_action(:action_name)` Tests that an action, passed in as a parameter,
   is permitted by the policy.
+* `permit_action(:action_name, *arguments)` Tests that an action and its argument(s),
+  passed in as parameters, is permitted by the policy.
 * `permit_actions([:action1, :action2])` Tests that an array of actions, passed
   in as a parameter, are permitted by the policy.
 * `permit_new_and_create_actions` Tests that both the new and create actions
@@ -55,6 +57,8 @@ files (by convention, saved in the `spec/policies` directory).
 
 * `forbid_action(:action_name)` Tests that an action, passed in as a parameter,
   is not permitted by the policy.
+* `forbid_action(:action_name, *arguments)` Tests that an action and its argument(s),
+  passed in as a parameter, is not permitted by the policy.
 * `forbid_actions([:action1, :action2])` Tests that an array of actions, passed
   in as a parameter, are not permitted by the policy.
 * `forbid_new_and_create_actions` Tests that both the new and create actions

--- a/lib/pundit/matchers.rb
+++ b/lib/pundit/matchers.rb
@@ -2,9 +2,13 @@ require 'rspec/core'
 
 module Pundit
   module Matchers
-    RSpec::Matchers.define :forbid_action do |action|
+    RSpec::Matchers.define :forbid_action do |action, *args|
       match do |policy|
-        !policy.public_send("#{action}?")
+        if args.any?
+          !policy.public_send("#{action}?", *args)
+        else
+          !policy.public_send("#{action}?")
+        end
       end
 
       failure_message do |policy|
@@ -128,9 +132,13 @@ module Pundit
     end
   end
 
-  RSpec::Matchers.define :permit_action do |action|
+  RSpec::Matchers.define :permit_action do |action, *args|
     match do |policy|
-      policy.public_send("#{action}?")
+      if args.any?
+        policy.public_send("#{action}?", *args)
+      else
+        policy.public_send("#{action}?")
+      end
     end
 
     failure_message do |policy|

--- a/pundit-matchers.gemspec
+++ b/pundit-matchers.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'pundit-matchers'
-  s.version     = '1.2.3'
+  s.version     = '1.3.0'
   s.date        = Time.now.strftime('%Y-%m-%d')
   s.summary     = 'RSpec matchers for Pundit policies'
   s.description = 'A set of RSpec matchers for testing Pundit authorisation ' \

--- a/spec/matchers/forbid_action_spec.rb
+++ b/spec/matchers/forbid_action_spec.rb
@@ -26,4 +26,60 @@ describe 'forbid_action matcher' do
     subject { ForbidActionTestPolicy2.new }
     it { is_expected.to forbid_action(:test) }
   end
+
+  context 'test_arg? is forbidden' do
+    before do
+      class ForbidActionTestPolicy3
+        def test_arg?(argument)
+          raise unless argument == 'argument'
+          true
+        end
+      end
+    end
+
+    subject { ForbidActionTestPolicy3.new }
+    it { is_expected.not_to forbid_action(:test_arg, 'argument') }
+  end
+
+  context 'test_arg? is forbidden' do
+    before do
+      class ForbidActionTestPolicy4
+        def test_arg?(argument)
+          raise unless argument == 'argument'
+          false
+        end
+      end
+    end
+
+    subject { ForbidActionTestPolicy4.new }
+    it { is_expected.to forbid_action(:test_arg, 'argument') }
+  end
+
+  context 'test_multiple_arg? is forbidden' do
+    before do
+      class ForbidActionTestPolicy5
+        def test_multiple_arg?(one, two, three)
+          raise unless one == 'one' && two == 'two' && three == 'three'
+          true
+        end
+      end
+    end
+
+    subject { ForbidActionTestPolicy5.new }
+    it { is_expected.not_to forbid_action(:test_multiple_arg, 'one', 'two', 'three') }
+  end
+
+  context 'test_multiple_arg? is forbidden' do
+    before do
+      class ForbidActionTestPolicy6
+        def test_multiple_arg?(one, two, three)
+          raise unless one == 'one' && two == 'two' && three == 'three'
+          false
+        end
+      end
+    end
+
+    subject { ForbidActionTestPolicy6.new }
+    it { is_expected.to forbid_action(:test_multiple_arg, 'one', 'two', 'three') }
+  end
 end

--- a/spec/matchers/permit_action_spec.rb
+++ b/spec/matchers/permit_action_spec.rb
@@ -26,4 +26,60 @@ describe 'permit_action matcher' do
     subject { PermitActionTestPolicy2.new }
     it { is_expected.not_to permit_action(:test) }
   end
+
+  context 'test_arg? is permitted' do
+    before do
+      class PermitActionTestPolicy3
+        def test_arg?(argument)
+          raise unless argument == 'argument'
+          true
+        end
+      end
+    end
+
+    subject { PermitActionTestPolicy3.new }
+    it { is_expected.to permit_action(:test_arg, 'argument') }
+  end
+
+  context 'test_arg? is forbidden' do
+    before do
+      class PermitActionTestPolicy4
+        def test_arg?(argument)
+          raise unless argument == 'argument'
+          false
+        end
+      end
+    end
+
+    subject { PermitActionTestPolicy4.new }
+    it { is_expected.not_to permit_action(:test_arg, 'argument') }
+  end
+
+  context 'test_multiple_arg? is permitted' do
+    before do
+      class PermitActionTestPolicy5
+        def test_multiple_arg?(one, two, three)
+          raise unless one == 'one' && two == 'two' && three == 'three'
+          true
+        end
+      end
+    end
+
+    subject { PermitActionTestPolicy5.new }
+    it { is_expected.to permit_action(:test_multiple_arg, 'one', 'two', 'three') }
+  end
+
+  context 'test_multiple_arg? is forbidden' do
+    before do
+      class PermitActionTestPolicy6
+        def test_multiple_arg?(one, two, three)
+          raise unless one == 'one' && two == 'two' && three == 'three'
+          false
+        end
+      end
+    end
+
+    subject { PermitActionTestPolicy6.new }
+    it { is_expected.not_to permit_action(:test_multiple_arg, 'one', 'two', 'three') }
+  end
 end


### PR DESCRIPTION
Hi

I am using this gem in conjunction with the [jsonapi-authorization](https://github.com/handlers/jsonapi-authorization/) gem. Jsonapi-authorization uses methods like `add_to_relation?(object)` on the policy. Since passing arguments to an action is not yet supported by `pundit-matchers`, I've added this feature and relevant tests.

Regards

Florian