### PR TITLE
Removes singularity check on `permit_actions` and `forbid_actions`

### DIFF
--- a/lib/pundit/matchers.rb
+++ b/lib/pundit/matchers.rb
@@ -35,16 +35,10 @@ module Pundit
     zero_actions_failure_message = 'At least two actions must be ' \
       'specified when using the forbid_actions matcher.'
 
-    one_action_failure_message = 'More than one action must be specified ' \
-      'when using the forbid_actions matcher. To test a single action, use ' \
-      'forbid_action instead.'
-
     failure_message do |policy|
       case actions.count
       when 0
         zero_actions_failure_message
-      when 1
-        one_action_failure_message
       else
         "#{policy.class} does not forbid #{actions} for " \
           "#{policy.user.inspect}."
@@ -55,8 +49,6 @@ module Pundit
       case actions.count
       when 0
         zero_actions_failure_message
-      when 1
-        one_action_failure_message
       else
         "#{policy.class} does not permit #{actions} for " \
           "#{policy.user.inspect}."
@@ -164,16 +156,10 @@ module Pundit
     zero_actions_failure_message = 'At least two actions must be ' \
       'specified when using the permit_actions matcher.'
 
-    one_action_failure_message = 'More than one action must be specified ' \
-      'when using the permit_actions matcher. To test a single action, use ' \
-      'permit_action instead.'
-
     failure_message do |policy|
       case actions.count
       when 0
         zero_actions_failure_message
-      when 1
-        one_action_failure_message
       else
         "#{policy.class} does not permit #{actions} for " \
           "#{policy.user.inspect}."


### PR DESCRIPTION
Remove check on `permit_actions` and `forbid_actions` that requires the passed array to have more than one action.

Discussion in #14 