### PR TITLE
splat arguments for permit_actions and forbid_actions matchers

### DIFF
--- a/lib/pundit/matchers.rb
+++ b/lib/pundit/matchers.rb
@@ -43,7 +43,8 @@ module Pundit
     end
   end
 
-  RSpec::Matchers.define :forbid_actions do |actions|
+  RSpec::Matchers.define :forbid_actions do |*actions|
+    actions.flatten!
     match do |policy|
       return false if actions.count < 1
       @allowed_actions = actions.select do |action|
@@ -204,7 +205,8 @@ module Pundit
     end
   end
 
-  RSpec::Matchers.define :permit_actions do |actions|
+  RSpec::Matchers.define :permit_actions do |*actions|
+    actions.flatten!
     match do |policy|
       return false if actions.count < 1
       @forbidden_actions = actions.reject do |action|


### PR DESCRIPTION
I found myself doing the following often
`it { should permit_actions(:update, :show) }`
I always forget that permit_actions can only accept an array and vice versa for forbid_actions.

My commit also keeps people in mind who like to pass array instead of mere arguments.