### PR TITLE
Add "permit_all_actions" and "forbid_all_actions" matchers

### DIFF
--- a/lib/pundit/matchers.rb
+++ b/lib/pundit/matchers.rb
@@ -2,6 +2,12 @@ require 'rspec/core'
 
 module Pundit
   module Matchers
+    require 'pundit/matchers/utils/policy_info'
+    require 'pundit/matchers/utils/all_actions/forbidden_actions_error_formatter'
+    require 'pundit/matchers/utils/all_actions/forbidden_actions_matcher'
+    require 'pundit/matchers/utils/all_actions/permitted_actions_error_formatter'
+    require 'pundit/matchers/utils/all_actions/permitted_actions_matcher'
+
     class Configuration
       attr_accessor :user_alias
 
@@ -340,6 +346,30 @@ module Pundit
       "#{policy.class} does not forbid the new or create action for " +
         policy.public_send(Pundit::Matchers.configuration.user_alias)
               .inspect + '.'
+    end
+  end
+
+  RSpec::Matchers.define :permit_all_actions do
+    match do |policy|
+      @matcher = Pundit::Matchers::Utils::AllActions::PermittedActionsMatcher.new(policy)
+      @matcher.match?
+    end
+
+    failure_message do
+      formatter = Pundit::Matchers::Utils::AllActions::PermittedActionsErrorFormatter.new(@matcher)
+      formatter.message
+    end
+  end
+
+  RSpec::Matchers.define :forbid_all_actions do
+    match do |policy|
+      @matcher = Pundit::Matchers::Utils::AllActions::ForbiddenActionsMatcher.new(policy)
+      @matcher.match?
+    end
+
+    failure_message do
+      formatter = Pundit::Matchers::Utils::AllActions::ForbiddenActionsErrorFormatter.new(@matcher)
+      formatter.message
     end
   end
 end

--- a/lib/pundit/matchers/utils/all_actions/actions_matcher.rb
+++ b/lib/pundit/matchers/utils/all_actions/actions_matcher.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Pundit
+  module Matchers
+    module Utils
+      module AllActions
+        # Parent class for specific all_action matcher. Should not be used directly.
+        #
+        # Expects methods in child class:
+        # * actual_actions - list of actions which actually matches expected type.
+        class ActionsMatcher
+          attr_reader :policy_info
+
+          def initialize(policy)
+            @policy_info = PolicyInfo.new(policy)
+          end
+
+          def match?
+            missed_expected_actions.empty?
+          end
+
+          def missed_expected_actions
+            @missed_expected_actions ||= expected_actions - actual_actions
+          end
+
+          def policy
+            policy_info.policy
+          end
+
+          private
+
+          def expected_actions
+            policy_info.actions
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pundit/matchers/utils/all_actions/error_message_formatter.rb
+++ b/lib/pundit/matchers/utils/all_actions/error_message_formatter.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Pundit
+  module Matchers
+    module Utils
+      module AllActions
+        # Adds #message method which generates failed assertion message
+        # for *_all_actions matchers.
+        #
+        # Expects methods to be defined:
+        # * matcher - instance which has `AllActions::ActionsMatcher` as a parent class
+        # * expected_kind - string with expected actions type (can be "forbidden" or "permitted")
+        # * opposite_kind - string with oposite then expected actions type (can be "permitted" or "forbidden")
+        module ErrorMessageFormatter
+          def message
+            "#{policy_name} expected to have all actions #{expected_kind}, " \
+            "but #{mismatches_are(missed_expected_actions)} #{opposite_kind}"
+          end
+
+          private
+
+          attr_reader :matcher, :expected_kind, :opposite_kind
+
+          def policy
+            matcher.policy
+          end
+
+          def missed_expected_actions
+            matcher.missed_expected_actions
+          end
+
+          def policy_name
+            policy.class.name
+          end
+
+          def mismatches_are(mismatches)
+            if mismatches.count == 1
+              "#{mismatches} is"
+            else
+              "#{mismatches} are"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pundit/matchers/utils/all_actions/forbidden_actions_error_formatter.rb
+++ b/lib/pundit/matchers/utils/all_actions/forbidden_actions_error_formatter.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'pundit/matchers/utils/all_actions/error_message_formatter'
+
+module Pundit
+  module Matchers
+    module Utils
+      module AllActions
+        # Error message formatter for `forbid_all_actions` matcher.
+        class ForbiddenActionsErrorFormatter
+          include AllActions::ErrorMessageFormatter
+
+          def initialize(matcher)
+            @expected_kind = 'forbidden'
+            @opposite_kind = 'permitted'
+            @matcher = matcher
+          end
+
+          private
+
+          attr_reader :matcher, :expected_kind, :opposite_kind
+        end
+      end
+    end
+  end
+end

--- a/lib/pundit/matchers/utils/all_actions/forbidden_actions_matcher.rb
+++ b/lib/pundit/matchers/utils/all_actions/forbidden_actions_matcher.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'pundit/matchers/utils/all_actions/actions_matcher'
+
+module Pundit
+  module Matchers
+    module Utils
+      module AllActions
+        # Handles all the checks in `forbid_all_actions` matcher.
+        class ForbiddenActionsMatcher < AllActions::ActionsMatcher
+          private
+
+          def actual_actions
+            policy_info.forbidden_actions
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pundit/matchers/utils/all_actions/permitted_actions_error_formatter.rb
+++ b/lib/pundit/matchers/utils/all_actions/permitted_actions_error_formatter.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'pundit/matchers/utils/all_actions/error_message_formatter'
+
+module Pundit
+  module Matchers
+    module Utils
+      module AllActions
+        # Error message formatter for `permit_all_actions` matcher.
+        class PermittedActionsErrorFormatter
+          include AllActions::ErrorMessageFormatter
+
+          def initialize(matcher)
+            @expected_kind = 'permitted'
+            @opposite_kind = 'forbidden'
+            @matcher = matcher
+          end
+
+          private
+
+          attr_reader :matcher, :expected_kind, :actual_kind
+        end
+      end
+    end
+  end
+end

--- a/lib/pundit/matchers/utils/all_actions/permitted_actions_matcher.rb
+++ b/lib/pundit/matchers/utils/all_actions/permitted_actions_matcher.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'pundit/matchers/utils/all_actions/actions_matcher'
+
+module Pundit
+  module Matchers
+    module Utils
+      module AllActions
+        # Handles all the checks in `permit_all_actions` matcher.
+        class PermittedActionsMatcher < AllActions::ActionsMatcher
+          private
+
+          def actual_actions
+            policy_info.permitted_actions
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pundit/matchers/utils/policy_info.rb
+++ b/lib/pundit/matchers/utils/policy_info.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Pundit
+  module Matchers
+    module Utils
+      # Collects all details about given policy class.
+      class PolicyInfo
+        attr_reader :policy
+
+        def initialize(policy)
+          @policy = policy
+        end
+
+        def actions
+          @actions ||= begin
+            policy_methods = @policy.public_methods - Object.instance_methods
+            policy_methods.grep(/\?$/).map { |policy_method| policy_method.to_s.sub(/\?$/, '').to_sym }
+          end
+        end
+
+        def permitted_actions
+          @permitted_actions ||= actions.select { |action| policy.public_send("#{action}?") }
+        end
+
+        def forbidden_actions
+          actions - permitted_actions
+        end
+      end
+    end
+  end
+end

--- a/spec/matchers/forbid_all_actions_spec.rb
+++ b/spec/matchers/forbid_all_actions_spec.rb
@@ -1,0 +1,89 @@
+require 'rspec/core'
+
+describe 'forbid_all_actions matcher' do
+  subject { policy_class.new }
+
+  context 'no actions are specified' do
+    let(:policy_class) { Class.new }
+
+    it { is_expected.to forbid_all_actions }
+  end
+
+  context 'one action is permitted' do
+    let(:policy_class) do
+      Class.new do
+        def test?
+          true
+        end
+      end
+    end
+
+    it { is_expected.not_to forbid_all_actions }
+  end
+
+  context 'more than one action is specified' do
+    context 'test1? and test2? are permitted' do
+      let(:policy_class) do
+        Class.new do
+          def test1?
+            true
+          end
+
+          def test2?
+            true
+          end
+        end
+      end
+
+      it { is_expected.not_to forbid_all_actions }
+    end
+
+    context 'test1? is permitted, test2? is forbidden' do
+      let(:policy_class) do
+        Class.new do
+          def test1?
+            true
+          end
+
+          def test2?
+            false
+          end
+        end
+      end
+
+      it { is_expected.not_to forbid_all_actions }
+    end
+
+    context 'test1? is forbidden, test2? is permitted' do
+      let(:policy_class) do
+        Class.new do
+          def test1?
+            false
+          end
+
+          def test2?
+            true
+          end
+        end
+      end
+
+      it { is_expected.not_to forbid_all_actions }
+    end
+
+    context 'test1? and test2? are both forbidden' do
+      let(:policy_class) do
+        Class.new do
+          def test1?
+            false
+          end
+
+          def test2?
+            false
+          end
+        end
+      end
+
+      it { is_expected.to forbid_all_actions }
+    end
+  end
+end

--- a/spec/matchers/permit_all_actions_spec.rb
+++ b/spec/matchers/permit_all_actions_spec.rb
@@ -1,0 +1,89 @@
+require 'rspec/core'
+
+describe 'permit_all_actions matcher' do
+  subject { policy_class.new }
+
+  context 'no actions are specified' do
+    let(:policy_class) { Class.new }
+
+    it { is_expected.to permit_all_actions }
+  end
+
+  context 'one action is permitted' do
+    let(:policy_class) do
+      Class.new do
+        def test?
+          true
+        end
+      end
+    end
+
+    it { is_expected.to permit_all_actions }
+  end
+
+  context 'more than one action is specified' do
+    context 'test1? and test2? are permitted' do
+      let(:policy_class) do
+        Class.new do
+          def test1?
+            true
+          end
+
+          def test2?
+            true
+          end
+        end
+      end
+
+      it { is_expected.to permit_all_actions }
+    end
+
+    context 'test1? is permitted, test2? is forbidden' do
+      let(:policy_class) do
+        Class.new do
+          def test1?
+            true
+          end
+
+          def test2?
+            false
+          end
+        end
+      end
+
+      it { is_expected.not_to permit_all_actions }
+    end
+
+    context 'test1? is forbidden, test2? is permitted' do
+      let(:policy_class) do
+        Class.new do
+          def test1?
+            false
+          end
+
+          def test2?
+            true
+          end
+        end
+      end
+
+      it { is_expected.not_to permit_all_actions }
+    end
+
+    context 'test1? and test2? are both forbidden' do
+      let(:policy_class) do
+        Class.new do
+          def test1?
+            false
+          end
+
+          def test2?
+            false
+          end
+        end
+      end
+
+      it { is_expected.not_to permit_all_actions }
+    end
+  end
+end

--- a/spec/matchers/utils/all_actions/forbidden_actions_error_formatter_spec.rb
+++ b/spec/matchers/utils/all_actions/forbidden_actions_error_formatter_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rspec/core'
+
+RSpec.describe Pundit::Matchers::Utils::AllActions::ForbiddenActionsErrorFormatter do
+  subject(:error_message_formatter) do
+    described_class.new(matcher)
+  end
+
+  let(:matcher) do
+    Pundit::Matchers::Utils::AllActions::ForbiddenActionsMatcher.new(policy)
+  end
+
+  let(:policy_class) do
+    Class.new do
+      def self.name
+        'DummyPolicy'
+      end
+
+      def initialize(update, create)
+        @update = update
+        @create = create
+      end
+
+      def update?
+        @update
+      end
+
+      def create?
+        @create
+      end
+    end
+  end
+
+  let(:policy) { policy_class.new(true, false) }
+
+  describe '#message' do
+    subject(:message) { error_message_formatter.message }
+
+    it 'includes missed actions in message' do
+      expect(message).to eq('DummyPolicy expected to have all actions forbidden, but [:update] is permitted')
+    end
+  end
+end

--- a/spec/matchers/utils/all_actions/forbidden_actions_matcher_spec.rb
+++ b/spec/matchers/utils/all_actions/forbidden_actions_matcher_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rspec/core'
+
+RSpec.describe Pundit::Matchers::Utils::AllActions::ForbiddenActionsMatcher do
+  subject(:only_permitted_actions_matcher) do
+    described_class.new(policy)
+  end
+
+  let(:policy_class) do
+    Class.new do
+      def initialize(update, create)
+        @update = update
+        @create = create
+      end
+
+      def update?
+        @update
+      end
+
+      def create?
+        @create
+      end
+    end
+  end
+
+  let(:policy) { policy_class.new(false, false) }
+
+  describe '#match?' do
+    context 'when policy forbids all actions' do
+      it { is_expected.to be_match }
+    end
+
+    context 'when policy allows all actions' do
+      let(:policy) { policy_class.new(true, true) }
+
+      it { is_expected.not_to be_match }
+    end
+
+    context 'when policy allows some actions' do
+      let(:policy) { policy_class.new(true, false) }
+
+      it { is_expected.not_to be_match }
+    end
+  end
+
+  describe '#missed_expected_actions' do
+    subject(:missed_expected_actions) { only_permitted_actions_matcher.missed_expected_actions }
+
+    context 'when policy forbids all actions' do
+      it { is_expected.to be_empty }
+    end
+
+    context 'when policy allows all actions' do
+      let(:policy) { policy_class.new(true, true) }
+
+      it 'returns actions which are permitted' do
+        expect(missed_expected_actions).to match_array(%i[create update])
+      end
+    end
+
+    context 'when policy allows some actions' do
+      let(:policy) { policy_class.new(true, false) }
+
+      it 'returns actions which are permitted' do
+        expect(missed_expected_actions).to match_array(%i[update])
+      end
+    end
+  end
+end

--- a/spec/matchers/utils/all_actions/permitted_actions_error_formatter_spec.rb
+++ b/spec/matchers/utils/all_actions/permitted_actions_error_formatter_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rspec/core'
+
+RSpec.describe Pundit::Matchers::Utils::AllActions::PermittedActionsErrorFormatter do
+  subject(:error_message_formatter) do
+    described_class.new(matcher)
+  end
+
+  let(:matcher) do
+    Pundit::Matchers::Utils::AllActions::PermittedActionsMatcher.new(policy)
+  end
+
+  let(:policy_class) do
+    Class.new do
+      def self.name
+        'DummyPolicy'
+      end
+
+      def initialize(update, create)
+        @update = update
+        @create = create
+      end
+
+      def update?
+        @update
+      end
+
+      def create?
+        @create
+      end
+    end
+  end
+
+  let(:policy) { policy_class.new(true, false) }
+
+  describe '#message' do
+    subject(:message) { error_message_formatter.message }
+
+    it 'includes missed actions in message' do
+      expect(message).to eq('DummyPolicy expected to have all actions permitted, but [:create] is forbidden')
+    end
+  end
+end

--- a/spec/matchers/utils/all_actions/permitted_actions_matcher_spec.rb
+++ b/spec/matchers/utils/all_actions/permitted_actions_matcher_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rspec/core'
+
+RSpec.describe Pundit::Matchers::Utils::AllActions::PermittedActionsMatcher do
+  subject(:only_permitted_actions_matcher) do
+    described_class.new(policy)
+  end
+
+  let(:policy_class) do
+    Class.new do
+      def initialize(update, create)
+        @update = update
+        @create = create
+      end
+
+      def update?
+        @update
+      end
+
+      def create?
+        @create
+      end
+    end
+  end
+
+  let(:policy) { policy_class.new(true, true) }
+
+  describe '#match?' do
+    context 'when policy allows all actions' do
+      it { is_expected.to be_match }
+    end
+
+    context 'when policy forbids all actions' do
+      let(:policy) { policy_class.new(false, false) }
+
+      it { is_expected.not_to be_match }
+    end
+
+    context 'when policy forbids some actions' do
+      let(:policy) { policy_class.new(false, true) }
+
+      it { is_expected.not_to be_match }
+    end
+  end
+
+  describe '#missed_expected_actions' do
+    subject(:missed_expected_actions) { only_permitted_actions_matcher.missed_expected_actions }
+
+    context 'when policy allows all actions' do
+      it { is_expected.to be_empty }
+    end
+
+    context 'when policy forbids all actions' do
+      let(:policy) { policy_class.new(false, false) }
+
+      it 'returns actions which are permitted' do
+        expect(missed_expected_actions).to match_array(%i[create update])
+      end
+    end
+
+    context 'when policy forbids some actions' do
+      let(:policy) { policy_class.new(false, true) }
+
+      it 'returns actions which are permitted' do
+        expect(missed_expected_actions).to match_array(%i[update])
+      end
+    end
+  end
+end

--- a/spec/matchers/utils/policy_info_spec.rb
+++ b/spec/matchers/utils/policy_info_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rspec/core'
+
+RSpec.describe Pundit::Matchers::Utils::PolicyInfo do
+  subject(:policy_info) { described_class.new(policy) }
+
+  let(:policy_class) do
+    Class.new do
+      def update?
+        false
+      end
+
+      def create?
+        true
+      end
+
+      def new?
+        true
+      end
+    end
+  end
+
+  let(:policy) { policy_class.new }
+
+  describe '#actions' do
+    subject(:actions) { policy_info.actions }
+
+    it 'returns correct actions' do
+      expect(actions).to match_array(%i[update create new])
+    end
+  end
+
+  describe '#permitted_actions' do
+    subject(:permitted_actions) { policy_info.permitted_actions }
+
+    it 'returns actions with "true" result only' do
+      expect(permitted_actions).to match_array(%i[create new])
+    end
+  end
+
+  describe '#forbidden_actions' do
+    subject(:forbidden_actions) { policy_info.forbidden_actions }
+
+    it 'returns actions with "false" result only' do
+      expect(forbidden_actions).to match_array(%i[update])
+    end
+  end
+end


### PR DESCRIPTION
Adds `permit_all_actions` and `forbid_all_actions` matchers.

Code is different and more complex than in other places, but it allows to build more advanced matchers too.