### PR TITLE
Add CODEOWNERS for dependabot and workflow updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Dependabot `bundler` ecosystem
+/Gemfile      @pundit-community/dependabot-reviewers
+/Gemfile.lock @pundit-community/dependabot-reviewers
+
+# Dependabot `github-actions` ecosystem
+/.github/workflows/* @pundit-community/dependabot-reviewers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - pundit-community/dependabot-reviewers
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
@@ -14,5 +12,3 @@ updates:
       rubocop:
         patterns:
           - "rubocop*"
-    reviewers:
-      - pundit-community/dependabot-reviewers


### PR DESCRIPTION
- Assign `@pundit-community/dependabot-reviewers` to Gemfile, Gemfile.lock, and .github/workflows/*
- Support review assignment for dependabot PRs and workflow file changes
- Remove need for reviewers field in `dependabot.yml`

Close #227